### PR TITLE
Fix senpai config file extension

### DIFF
--- a/posts/irc.md
+++ b/posts/irc.md
@@ -68,10 +68,10 @@ Create a config file
 
 ```bash
 mkdir -p ~/.config/senpai
-touch ~/.config/senpai/senpai.cfg
+touch ~/.config/senpai/senpai.scfg
 ```
 
-Edit `senpai.cfg`
+Edit `senpai.scfg`
 
 ```
 address ircs://irc.pico.sh:6697


### PR DESCRIPTION
It seems the correct file extension for the configuration file for `senpai` is `scfg`, not `cfg` as the IRC page indicates.

If a `cfg` file is used, `senpai` warns the user it didn't find the `~/.config/senpai/senpai.scfg` and then starts the configuration assistant.

I also confirm `senpai` uses `scfg` checking `config.go` file: <https://git.sr.ht/~delthas/senpai/tree/master/item/config.go>.

If you think there is any other place in which `cfg` is used instead of `scfg`, I can check it and add to this PR.