### PR TITLE
docs(tuns): Document how to access client IPs

### DIFF
--- a/posts/tuns.md
+++ b/posts/tuns.md
@@ -109,3 +109,31 @@ autossh -M 0 -R dev:80:localhost:8000 tuns.sh
   <p>Create an account using only your SSH key.</p>
   <a href="/getting-started" class="btn-link">Get Started</a>
 </div>
+
+# Accessing the real client IP
+
+When an HTTP request is forwarded to your service, tuns automatically appends the following standard headers:
+
+* [`X-Forwarded-For`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+* [`X-Forwarded-Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host)
+* [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)
+
+Here is an example request that came from `203.0.113.12`:
+
+```
+GET / HTTP/1.1
+Host: example-project.tuns.sh
+User-Agent: curl/8.7.1
+Accept: */*
+X-Forwarded-For: 198.51.100.10, 203.0.113.12
+X-Forwarded-Host: example-project.tuns.sh
+X-Forwarded-Port: 443
+X-Forwarded-Proto: https
+X-Forwarded-Server: oracle2
+X-Real-Ip: 198.51.100.10
+Accept-Encoding: gzip
+```
+
+Each proxy that the request passes through will add a new value to the right of `X-Forwarded-For`. In most cases, you can obtain the real client IP address by reading the right-most value of `X-Forwarded-For`.
+
+Do not trust the `X-Real-Ip` header or the other values in `X-Forwarded-For` since those can be spoofed. Please read the [security and privacy concerns](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#security_and_privacy_concerns) section for more details.


### PR DESCRIPTION
Services running behind tuns.sh can access the client IP via `X-Forwarded-For` header, which is set by Caddy: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy

I chose to document this here instead of the sish docs because sish just passes these headers along; it doesn't set them itself.

The use-case for this is enforcing IP bans or IP allow-lists for services running on tuns.sh.