### PR TITLE
docs: nav: Use flex-wrap on narrow viewports.

### DIFF
--- a/static/smol.css
+++ b/static/smol.css
@@ -409,6 +409,10 @@ figure {
   flex-direction: column;
 }
 
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
 .items-center {
   align-items: center;
 }

--- a/tmpl/nav.partial.tmpl
+++ b/tmpl/nav.partial.tmpl
@@ -1,6 +1,6 @@
 {{define "nav"}}
 <nav class="mk-nav">
-  <div class="flex items-center justify-center gap-2" style="margin-right: 20px;">
+  <div class="flex flex-wrap items-center justify-center gap-2" style="margin-right: 20px;">
     <div class="group-h" style="gap: 0.25rem;">
       <svg width="22" height="22" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path class="logo" d="M107.301 39C111.645 46.5241 113.954 55.0503 113.999 63.7382C114.045 72.4262 111.826 80.9761 107.561 88.5452C103.296 96.1144 97.1319 102.442 89.677 106.903C82.222 111.365 73.7332 113.807 65.047 113.989C56.3608 114.171 47.7772 112.086 40.1419 107.941C32.5067 103.795 26.0835 97.7316 21.5053 90.3476C16.9271 82.9637 14.3519 74.5142 14.0336 65.832C13.7152 57.1497 15.6647 48.5344 19.6899 40.835L64 64L107.301 39Z" stroke="#414558" stroke-width="12"/>


### PR DESCRIPTION
This should prevent the nav links from getting cut off when there isn't enough width to display them in a single row.

| Before | After |
|---|---|
| ![Screenshot showing only some of the nav links are visible in a tiny viewport](https://github.com/user-attachments/assets/1d510f2e-ef29-41a1-9854-3fc5265cda23) | ![Screenshot showing all of the nav links are visible in a tiny viewport in multiple rows](https://github.com/user-attachments/assets/2616adb6-5fdf-4f49-9cc0-3a8ce7eea918) |


