### PR TITLE
docs(bouncer): Fix links to soju and gamja repos

### DIFF
--- a/posts/bouncer.md
+++ b/posts/bouncer.md
@@ -125,6 +125,6 @@ That's it! Join any other channels or networks using the same method.
 - [libera.chat](https://libera.chat)
 - [pico bouncer](ircs://irc.pico.sh:6697)
 - [soju man page](https://soju.im/doc/soju.1.html)
-- [soju](https://git.sr.ht/~emersion/soju)
-- [gamja](https://git.sr.ht/~emersion/gamja)
+- [soju](https://codeberg.org/emersion/soju)
+- [gamja](https://codeberg.org/emersion/gamja)
 - [senpai](https://git.sr.ht/~delthas/senpai)


### PR DESCRIPTION
[soju][0] and [gamja][1] development has been moved to Codeberg.

[0]: https://git.sr.ht/~emersion/soju/commit/65410474ca95e00162b9a42752017f8e49de42e7
[1]: https://git.sr.ht/~emersion/gamja/commit/32012bbea536eff9eea393ec1d66b048e4bbf024