### PR TITLE
docs: add pipe.pico.sh to ssh hosts

### DIFF
--- a/posts/faq.md
+++ b/posts/faq.md
@@ -60,7 +60,7 @@ ssh -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 pico.sh
 The other is with an SSH config entry (`~/.ssh/config`):
 
 ```bash
-Host pico.sh pgs.sh prose.sh tuns.sh
+Host pico.sh pgs.sh prose.sh tuns.sh pipe.pico.sh
   IdentitiesOnly yes
   IdentityFile ~/.ssh/id_ed25519
 ```


### PR DESCRIPTION
Was confused why ssh was picking the wrong key for me locally for pipes, and this was why.