### PR TITLE
Remove curly braces and quotes in DNS record examples

### DIFF
--- a/posts/custom-domains.md
+++ b/posts/custom-domains.md
@@ -34,7 +34,7 @@ addresses by running `host pgs.sh`.
 
 ```
 subdomain.yourcustomdomain.com.         300     IN      A       129.158.37.104.
-_pgs.subdomain.yourcustomdomain.com.    300     IN      TXT     "{user}-{project}"
+_pgs.subdomain.yourcustomdomain.com.    300     IN      TXT     user-project
 ```
 
 # Can I use an `ALIAS` record instead of `CNAME`?
@@ -43,5 +43,5 @@ Yes, it should work the exact same way.
 
 ```
 subdomain.yourcustomdomain.com.         300     IN      ALIAS   pgs.sh.
-_pgs.subdomain.yourcustomdomain.com.    300     IN      TXT     "{user}-{project}"
+_pgs.subdomain.yourcustomdomain.com.    300     IN      TXT     user-project
 ```


### PR DESCRIPTION
I thought about changing the curly braces to </> but I don't think that would be necessarily clearer. And since no special symbols is used elsewhere in the example, I opted for a similar approach (e,g, no symbols around the sub/domain names).

I also removed the quotes. I'm guessing they are also unnecessary. My registrar automatically removes them on my end.