### PR TITLE
Update rsync example in FAQ to match SCP example and correct pico.sh address

### DIFF
--- a/posts/faq.md
+++ b/posts/faq.md
@@ -114,7 +114,7 @@ pubkeys on the pico platform.
 ```bash
 rsync pico.sh:/authorized_keys .
 # edit keys (add, remove, edit comments)
-rsync ./authorized_keys pico.sh
+rsync ./authorized_keys pico.sh:/
 ```
 
 > Caveat: as a safety precaution, we will **never** remove the pubkey currently


### PR DESCRIPTION
Previous command will `rsync` to the file named `pico.sh`

![image](https://github.com/user-attachments/assets/45851c59-3e9c-4b02-b557-8c56970f489f)

Thank you guys for the service! I've really been enjoying it.